### PR TITLE
chore(compatibility): improve meteor compatibility

### DIFF
--- a/src/classes/ddpSubscription.js
+++ b/src/classes/ddpSubscription.js
@@ -16,14 +16,14 @@ export class ddpSubscription {
 		this._ready = false;
 
     this.selfReadyEvent = ddplink.on('ready', (m) => {
-      if (m.subs.includes(this.subid)) {
+      if (m.subs.includes(this.subscriptionId)) {
         this._ready = true;
         this._nosub = false;
       }
     });
 
     this.selfNosubEvent = ddplink.on('nosub', (m) => {
-      if (m.id==this.subid) {
+      if (m.id==this.subscriptionId) {
         this._ready = false;
         this._nosub = true;
         this._started = false;
@@ -44,7 +44,7 @@ export class ddpSubscription {
       f();
     } else {
       let onNs = this._ddplink.on('nosub', (m) => {
-        if (m.id==this.subid) {
+        if (m.id==this.subscriptionId) {
           f(m.error);
         }
       });
@@ -64,7 +64,7 @@ export class ddpSubscription {
 			f();
 		} else {
 			let onReady = this._ddplink.on('ready', (m) => {
-				if (m.subs.includes(this.subid)) {
+				if (m.subs.includes(this.subscriptionId)) {
 					f();
 				}
 			});
@@ -101,14 +101,14 @@ export class ddpSubscription {
         resolve();
       } else {
         let onReady = this._ddplink.on('ready', (m) => {
-  				if (m.subs.includes(this.subid)) {
+  				if (m.subs.includes(this.subscriptionId)) {
   					onReady.stop();
             onNosub.stop();
   					resolve();
   				}
   			});
         let onNosub = this._ddplink.on('nosub', (m) => {
-  				if (m.id == this.subid) {
+  				if (m.id == this.subscriptionId) {
   					onNosub.stop();
             onReady.stop();
   					reject(m.error);
@@ -129,7 +129,7 @@ export class ddpSubscription {
         resolve();
       } else {
         let onNosub = this._ddplink.on('nosub', (m) => {
-          if (m.id==this.subid) {
+          if (m.id==this.subscriptionId) {
             this._nosub = true;
 
             onNosub.stop();
@@ -175,7 +175,7 @@ export class ddpSubscription {
       // stopping ready listener
       this.selfReadyEvent.stop();
       // unsubscribing
-      if (!this._nosub) this._ddplink.ddpConnection.unsub(this.subid);
+      if (!this._nosub) this._ddplink.ddpConnection.unsub(this.subscriptionId);
 			this._started = false;
 			this._ready = false;
 		}
@@ -188,7 +188,7 @@ export class ddpSubscription {
 	 * @return {Promise}
 	 */
 	_getId() {
-		return this.subid;
+		return this.subscriptionId;
 	}
 
 	/**
@@ -203,7 +203,7 @@ export class ddpSubscription {
       // starting ready listener
       this.selfReadyEvent.start();
       // subscribing
-			this.subid = this._ddplink.ddpConnection.sub(this.subname,Array.isArray(args)?args:this.args);
+			this.subscriptionId = this._ddplink.ddpConnection.sub(this.subname,Array.isArray(args)?args:this.args);
 			this._started = true;
 		}
     return this.ready();

--- a/src/simpleddp.js
+++ b/src/simpleddp.js
@@ -72,6 +72,8 @@ export default class simpleDDP {
 		// Compatibility with Meteor connections
 		// See https://docs.meteor.com/api/methods.html#Meteor-apply
 		this.apply = this.call;
+		// See https://docs.meteor.com/api/pubsub.html#Meteor-subscribe
+		this.subscribe = (pub, ...args) => this.sub(pub, args);
 
 		// plugin init section
 		pluginConnector('init','beforeConnected');

--- a/src/simpleddp.js
+++ b/src/simpleddp.js
@@ -69,6 +69,10 @@ export default class simpleDDP {
 
 		let pluginConnector = connectPlugins.bind(this,plugins);
 
+		// Compatibility with Meteor connections
+		// See https://docs.meteor.com/api/methods.html#Meteor-apply
+		this.apply = this.call;
+
 		// plugin init section
 		pluginConnector('init','beforeConnected');
 

--- a/test/test_call.js
+++ b/test/test_call.js
@@ -30,6 +30,24 @@ describe('simpleDDP', function(){
 
   });
 
+  describe('#apply', function (){
+
+    it('should return promise and afterwards then function should run', function (done) {
+
+      server.apply("somemethod").then(function() {
+        done();
+      });
+
+      server.ddpConnection.emit('result',{
+        msg: 'result',
+        id: '1',
+        result: 'ok'
+      });
+
+    });
+
+  });
+
   after(function() {
     // runs after all tests in this block
     server.disconnect();

--- a/test/test_sub.js
+++ b/test/test_sub.js
@@ -83,6 +83,40 @@ describe('simpleDDP', function(){
 
   });
 
+  describe('#subribe', function (){
+
+    it('has the same functionanly as sub, but different syntax', async function () {
+
+      let subscriptionId = "";
+
+      setTimeout(function(){
+        server.ddpConnection.emit('added',{
+          msg: 'added',
+          collection: "test",
+          id: '0',
+          fields: {isOk:true}
+        });
+
+        server.ddpConnection.emit('ready',{
+          msg: 'ready',
+          subs: [subscriptionId]
+        });
+      },10);
+
+      let sub = await server.subscribe("testsub");
+      subscriptionId = sub.subscriptionId;
+
+      await sub.ready();
+
+      assert.deepEqual(server.collections['test'][0],{
+        id: '0',
+        isOk: true
+      });
+
+    });
+
+  });
+
   after(function() {
     // runs after all tests in this block
     server.disconnect();

--- a/test/test_sub.js
+++ b/test/test_sub.js
@@ -16,7 +16,7 @@ describe('simpleDDP', function(){
 
     it('should subscribe and simpleDDP.collections should update', async function () {
 
-      let subid = "";
+      let subscriptionId = "";
 
       setTimeout(function(){
         server.ddpConnection.emit('added',{
@@ -28,12 +28,12 @@ describe('simpleDDP', function(){
 
         server.ddpConnection.emit('ready',{
           msg: 'ready',
-          subs: [subid]
+          subs: [subscriptionId]
         });
       },10);
 
       let sub = await server.sub("testsub");
-      subid = sub.subid;
+      subscriptionId = sub.subscriptionId;
 
       await sub.ready();
 
@@ -46,7 +46,7 @@ describe('simpleDDP', function(){
 
     it('should subscribe and simpleDDP.collections should update, await sub ready should work both times', async function () {
 
-      let subid = "";
+      let subscriptionId = "";
 
       setTimeout(function(){
         server.ddpConnection.emit('added',{
@@ -58,12 +58,12 @@ describe('simpleDDP', function(){
 
         server.ddpConnection.emit('ready',{
           msg: 'ready',
-          subs: [subid]
+          subs: [subscriptionId]
         });
       },10);
 
       let sub = await server.sub("testsub");
-      subid = sub.subid;
+      subscriptionId = sub.subscriptionId;
 
       await sub.ready();
 


### PR DESCRIPTION
I'm trying to improve Meteor compatibility to make it easier for users to use non-Meteor DDP clients with [DDP-Apollo](https://github.com/Swydo/ddp-apollo).

While trying out SimpleDDP I noticed some function names and attributes didn't match. This is from the DDP-Apollo client readme:

```js
const SimpleDDP = require('simpleddp');

const ddp = new SimpleDDP({
    endpoint: 'ws://localhost:3000/websocket',
    SocketConstructor: global.WebSocket,
});

// SimpleDDP has a different API than the default DDP client
// We need to map some functions to a format which the DDP link understands
ddp.apply = ddp.call;
ddp.subscribe = (pub, ...args) => ddp.sub(pub, args);

this.link = getDDPLink({
    connection: ddp,
    socket: ddp.ddpConnection.socket,
    subscriptionIdKey: 'subid',
});
```
https://github.com/Swydo/ddp-apollo/tree/master/packages/apollo-link-ddp#setup-with-simpleddp

I was wondering if we could clean this up so they wouldn't need to do these modifications themselves.

The changes:

- Change `subid` to `subscriptionId`, which is [what Meteor uses in their subscription handles](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe). This is the least impactful change I think. Any reason not to change this?
- Add an [apply function](https://docs.meteor.com/api/methods.html#Meteor-apply). This is available on Meteor connections and matches the call syntax in SimpleDDP. Was their a reason to only add call and use the apply syntax?
- Add a [subscribe function](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe) which takes multiple arguments instead of an array. This isn't a very clear addition to SimpleDDP, but simply what I was expecting (and what DDP-Apollo uses underwater), because Meteor normally has a `subscribe` and not `sub` functions.

Please let me know what you think and if any of these changes could be added to make the setup for DDP-Apollo a little smoother for SimpleDDP users.

Cheers.