### PR TITLE
Avoid throwing uncaught exception if no `.error ` property exist on nosub message.

### DIFF
--- a/src/classes/ddpSubscription.js
+++ b/src/classes/ddpSubscription.js
@@ -111,7 +111,7 @@ export class ddpSubscription {
   				if (m.id == this.subscriptionId) {
   					onNosub.stop();
             onReady.stop();
-  					reject(m);
+  					reject(m.error | m);
   				}
   			});
       }

--- a/src/classes/ddpSubscription.js
+++ b/src/classes/ddpSubscription.js
@@ -111,7 +111,7 @@ export class ddpSubscription {
   				if (m.id == this.subscriptionId) {
   					onNosub.stop();
             onReady.stop();
-  					reject(m.error | m);
+  					reject(m.error || m);
   				}
   			});
       }

--- a/src/classes/ddpSubscription.js
+++ b/src/classes/ddpSubscription.js
@@ -111,7 +111,7 @@ export class ddpSubscription {
   				if (m.id == this.subscriptionId) {
   					onNosub.stop();
             onReady.stop();
-  					reject(m.error);
+  					reject(m);
   				}
   			});
       }


### PR DESCRIPTION
currently, when this error happens on my application the ".error" does not exist and yields an error.

As an attempt to close #25