### PR TITLE
Specify real return type instead of 'Object' and add missing parameter names in documentation

### DIFF
--- a/src/classes/ddpCollection.js
+++ b/src/classes/ddpCollection.js
@@ -97,7 +97,7 @@ export class ddpCollection {
    * @see ddpReactiveCollection
    * @public
    * @param {Object} [settings={skip:0,limit:Infinity,sort:null}]
-   * @return {Object} - @see ddpReactiveCollection
+   * @return {ddpReactiveCollection}
    */
   reactive(settings) {
     return new ddpReactiveCollection(this,settings,this._filter);
@@ -109,7 +109,7 @@ export class ddpCollection {
    * @public
    * @param {Function} f
    * @param {Function} filter
-   * @return {Object} - @see ddpOnChange
+   * @return {ddpOnChange}
    */
   onChange(f,filter) {
     let obj = {

--- a/src/classes/ddpReactiveCollection.js
+++ b/src/classes/ddpReactiveCollection.js
@@ -253,7 +253,7 @@ export class ddpReactiveCollection {
 	/**
    * Updates the skip parameter only.
    * @public
-   * @param {number} - A number of documents to skip.
+   * @param {number} n - A number of documents to skip.
 	 * @return {this}
    */
 	skip(n) {
@@ -263,7 +263,7 @@ export class ddpReactiveCollection {
 	/**
    * Updates the limit parameter only.
    * @public
-   * @param {number} - A number of documents to observe.
+   * @param {number} n - A number of documents to observe.
 	 * @return {this}
    */
 	limit(n) {


### PR DESCRIPTION
When generating types using typescript, it will use the type between the {} which was object which can be anything. This improves type checking.